### PR TITLE
fix vfs_read issue for large reads

### DIFF
--- a/sqltorrent.cpp
+++ b/sqltorrent.cpp
@@ -106,7 +106,7 @@ int vfs_device_characteristics(sqlite3_file*)
 	return SQLITE_IOCAP_IMMUTABLE;
 }
 
-int vfs_read(sqlite3_file* file, void* buffer, int iAmt, sqlite3_int64 iOfst)
+int vfs_read(sqlite3_file* file, void* buffer, int const iAmt, sqlite3_int64 const iOfst)
 {
 	using namespace libtorrent;
 
@@ -150,6 +150,7 @@ int vfs_read(sqlite3_file* file, void* buffer, int iAmt, sqlite3_int64 iOfst)
 			break;
 		}
 
+		++piece_idx;
 		piece_offset = 0;
 	} while (residue > 0);
 


### PR DESCRIPTION
I haven't actually tested this, but from inspecting the code, I think there's a bug. possibly it has never been hit if the piece size is large enough to cause reads to almost always fall into a single piece.

this code could also be optimized by setting the piece deadline for all pieces up front, and then pop all alerts per call, instead of popping one at a time.
